### PR TITLE
fix: fix imports in content.js to support Chrome extension content script environment

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,22 +1,49 @@
-import { formatJSON, minifyJSON } from './utils.js';
-import { isValidJSON } from './utils/validateJSON.js';
+
+function isValidJSON(str) {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch {
+    console.warn('[JSON Snap] Skipped: invalid JSON');
+    return false;
+  }
+}
+
+
+function formatJSON(jsonString) {
+  try {
+    const obj = JSON.parse(jsonString);
+    return JSON.stringify(obj, null, 2);
+  } catch {
+    return jsonString;
+  }
+}
+
+function minifyJSON(jsonString) {
+  try {
+    const obj = JSON.parse(jsonString);
+    return JSON.stringify(obj);
+  } catch {
+    return jsonString;
+  }
+}
+
 
 let useMinify = false;
 
 function formatPageJSON() {
+  console.log('[JSON Snap] content.js loaded');
+
   const pre = document.querySelector('pre');
   if (!pre) return;
 
   const raw = pre.textContent;
 
   if (!isValidJSON(raw)) {
-    console.warn('[JSON Snap] Skipped: invalid JSON');
     return;
   }
 
-  const formatted = useMinify
-    ? minifyJSON(raw)
-    : formatJSON(raw);
+  const formatted = useMinify ? minifyJSON(raw) : formatJSON(raw);
 
   if (formatted !== raw) {
     pre.textContent = formatted;


### PR DESCRIPTION
Removed all ES module `import` statements from `content.js` and inlined utility functions to ensure compatibility with Chrome extension content scripts.

This resolves the "Cannot use import statement outside a module" runtime error and allows the extension to run properly without bundlers.
